### PR TITLE
Update for shell best-practice / portability

### DIFF
--- a/ttar
+++ b/ttar
@@ -28,9 +28,12 @@ export LC_ALL=C
 
 path=""
 CMD=""
-ARG_STRING="$*"
+printf -v ARG_STRING '%q ' "$@"
+ARG_STRING=${ARG_STRING% }
 
-PYTHON=${PYTHON:-python}
+if [ -n "${PYTHON:-}" ] && ! declare -f python >/dev/null 2>&1; then
+    python() { "$PYTHON" "$@"; }
+fi
 
 #------------------------------------------------------------------------------
 # Not all sed implementations can work on null bytes. In order to make ttar
@@ -63,10 +66,10 @@ for line in sys.stdin:
 PEF
 )
 
-function test_environment {
+test_environment() {
     if [[ "$(echo "a" | sed 's/a/\x0/' | wc -c)" -ne 2 ]]; then
         echo "WARNING sed unable to handle null bytes, using Python (slow)."
-        if ! which python >/dev/null; then
+        if ! command -v python &>/dev/null; then
             echo "ERROR Python not found. Aborting."
             exit 2
         fi
@@ -76,7 +79,7 @@ function test_environment {
 
 #------------------------------------------------------------------------------
 
-function usage {
+usage() {
     bname=$(basename "$0")
     cat << USAGE
 Usage:   $bname [-C <DIR>] -c -f <ARCHIVE> <FILE...> (create archive)
@@ -95,13 +98,13 @@ USAGE
 exit "$1"
 }
 
-function vecho {
-    if [ "${VERBOSE:-}" == "yes" ]; then
+vecho() {
+    if [ "${VERBOSE:-}" = "yes" ]; then
         echo >&7 "$@"
     fi
 }
 
-function set_cmd {
+set_cmd() {
     if [ -n "$CMD" ]; then
         echo "ERROR: more than one command given"
         echo
@@ -143,7 +146,7 @@ while getopts :cf:-:htxvC: opt; do
                     RECURSIVE_UNLINK="yes"
                     ;;
                 *)
-                    echo -e "Error: invalid option -$OPTARG"
+                    echo >&2 "Error: invalid option -$OPTARG"
                     echo
                     usage 1
                     ;;
@@ -160,17 +163,17 @@ done
 # Remove processed options from arguments
 shift $(( OPTIND - 1 ));
 
-if [ "${CMD:-}" == "" ]; then
+if [ "${CMD:-}" = "" ]; then
     echo >&2 "ERROR: no command given"
     echo
     usage 1
-elif [ "${ARCHIVE:-}" == "" ]; then
+elif [ "${ARCHIVE:-}" = "" ]; then
     echo >&2 "ERROR: no archive name given"
     echo
     usage 1
 fi
 
-function list {
+list() {
     local path=""
     local size=0
     local line_no=0
@@ -205,7 +208,7 @@ function list {
     done < "$ttar_file"
 }
 
-function extract {
+extract() {
     local path=""
     local size=0
     local line_no=0
@@ -236,12 +239,12 @@ function extract {
             # Remove one backslash in front of NULLBYTE (if any)
             # Remove EOF unless preceded by backslash
             # Remove one backslash in front of EOF
-            if [ $USE_PYTHON -eq 1 ]; then
-                echo -n "$line" | $PYTHON -c "$PYTHON_EXTRACT_FILTER" >> "$path"
+            if [ "$USE_PYTHON" -eq 1 ]; then
+                printf '%s' "$line" | python -c "$PYTHON_EXTRACT_FILTER" >> "$path"
             else
                 # The repeated pattern makes up for sed's lack of negative
                 # lookbehind assertions (for consecutive null bytes).
-                echo -n "$line" | \
+                printf '%s' "$line" | \
                     sed -e 's/^NULLBYTE/\x0/g;
                             s/\([^\\]\)NULLBYTE/\1\x0/g;
                             s/\([^\\]\)NULLBYTE/\1\x0/g;
@@ -296,12 +299,12 @@ function extract {
     done < "$ttar_file"
 }
 
-function div {
+div() {
     echo "# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -" \
          "- - - - - -"
 }
 
-function get_mode {
+get_mode() {
     local mfile=$1
     if [ -z "${STAT_OPTION:-}" ]; then
         if stat -c '%a' "$mfile" >/dev/null 2>&1; then
@@ -318,7 +321,7 @@ function get_mode {
     stat "${STAT_OPTION}" "${STAT_FORMAT}" "$mfile"
 }
 
-function _create {
+_create() {
     shopt -s nullglob
     local mode
     local eof_without_newline
@@ -356,7 +359,7 @@ function _create {
             # Add backslash in front of NULLBYTE
             # Replace null byte with NULLBYTE
             if [ $USE_PYTHON -eq 1 ]; then
-                < "$file" $PYTHON -c "$PYTHON_CREATE_FILTER"
+                < "$file" python -c "$PYTHON_CREATE_FILTER"
             else
                 < "$file" \
                     sed 's/EOF/\\EOF/g;
@@ -374,14 +377,14 @@ function _create {
             vecho "$mode $file"
             div
         else
-            echo >&2 "ERROR: file not found ($file in $(pwd))"
+            echo >&2 "ERROR: file not found ($file in $PWD)"
             exit 2
         fi
         shift
     done
 }
 
-function create {
+create() {
     ttar_file=$1
     shift
     if [ -z "${1:-}" ]; then
@@ -403,7 +406,7 @@ if [ -n "${CDIR:-}" ]; then
     if [[ "$ARCHIVE" != /* ]]; then
         # Relative path: preserve the archive's location before changing
         # directory
-        ARCHIVE="$(pwd)/$ARCHIVE"
+        ARCHIVE="$PWD/$ARCHIVE"
     fi
     cd "$CDIR"
 fi


### PR DESCRIPTION
- Avoid external (OS-vendor-provided) `which` command in favor of shell-builtin and POSIX-defined `command -v` syntax. See also shellcheck warning [SC2230](https://www.shellcheck.net/wiki/SC2230).
- Avoid `echo -n` and `echo -e`; POSIX [does not specify](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html) either (except to say that output is undefined when the former is used), and whether bash supports them depends on both compile-time flags and runtime flags that can be modified based on environment variable contents at startup time.
- Avoid [legacy ksh function declaration syntax](https://wiki.bash-hackers.org/scripting/obsolete). In ksh (but not bash), `function funcname {` modifies whether variables declared in a function are local; in bash, it has no runtime difference whatsoever from the standardized `funcname() {` syntax.
- Avoid using `==` inside of `[`; the only [POSIX-defined](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html) string comparison operator is `=`.
- Use `$PWD` rather than the much slower `$(pwd)` construct.

Unaddressed in this PR: Using all-caps variable names ([namespace reserved](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html) for variables meaningful to the operating system and shell -- when reading the linked specification, keep in mind that modifying a shell variable updates any like-named environment variable), and use of `errexit` (which has [deeply unintuitive](http://mywiki.wooledge.org/BashFAQ/105#Exercises) and [nonportable](https://www.in-ulm.de/~mascheck/various/set-e/) behavior; explicit error handling is more consistent and thus easier to audit).