### PR TITLE
Update for recent python versions

### DIFF
--- a/ttar
+++ b/ttar
@@ -43,8 +43,8 @@ import re
 import sys
 
 for line in sys.stdin:
-    line = re.sub(r'EOF', r'\EOF', line)
-    line = re.sub(r'NULLBYTE', r'\NULLBYTE', line)
+    line = re.sub(r'EOF', r'\\EOF', line)
+    line = re.sub(r'NULLBYTE', r'\\NULLBYTE', line)
     line = re.sub('\x00', r'NULLBYTE', line)
     sys.stdout.write(line)
 PCF


### PR DESCRIPTION
The python code was initially conceived as a work-around for macOS which
shipped an unsuitable sed but a working python 2 interpreter. Now that
python 2 is no longer supported, ttar is expected to work with python 3.
At least with more recent versions of python 3, it fails with the
following error:

  Traceback (most recent call last):
    File "/usr/lib64/python3.10/sre_parse.py", line 1051, in parse_template
      this = chr(ESCAPES[this][1])
  KeyError: '\\E'

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "<string>", line 7, in <module>
    File "/usr/lib64/python3.10/re.py", line 209, in sub
      return _compile(pattern, flags).sub(repl, string, count)
    File "/usr/lib64/python3.10/re.py", line 326, in _subx
      template = _compile_repl(template, pattern)
    File "/usr/lib64/python3.10/re.py", line 317, in _compile_repl
      return sre_parse.parse_template(repl, pattern)
    File "/usr/lib64/python3.10/sre_parse.py", line 1054, in parse_template
      raise s.error('bad escape %s' % this, len(this))
  re.error: bad escape \E at position 0

This change makes the python code work with both python 2 and recent
python 3 versions (tested with python 2.7.18 and 3.10.5).